### PR TITLE
fix: tournaments page: always render dynamically

### DIFF
--- a/frontend/app/tournaments/page.tsx
+++ b/frontend/app/tournaments/page.tsx
@@ -2,6 +2,8 @@ import TournamentsOverview from "@/components/tournament/TournamentsOverview";
 import React from "react";
 import styles from "@/styles/page.module.css";
 
+export const dynamic = 'force-dynamic';
+
 export default function TournamentsPage() {
     return (
         <div className={styles.container}>


### PR DESCRIPTION
Fix for build error:
An error Occured:  Error: Dynamic server usage: Route /tournaments couldn't be rendered statically because it used `cookies`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error
    at m (.next/server/chunks/447.js:12:42338)
    at c (.next/server/chunks/870.js:63:270044)
    at o (.next/server/chunks/734.js:1:1062)
    at d (.next/server/app/tournaments/page.js:1:779)
    at b (.next/server/app/tournaments/page.js:1:8607)
    at stringify (<anonymous>) {
  description: "Route /tournaments couldn't be rendered statically because it used `cookies`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error",
  digest: 'DYNAMIC_SERVER_USAGE'